### PR TITLE
Habilitando CORS na API

### DIFF
--- a/src/main/java/br/com/caelum/carangobom/config/CorsConfig.java
+++ b/src/main/java/br/com/caelum/carangobom/config/CorsConfig.java
@@ -1,0 +1,16 @@
+package br.com.caelum.carangobom.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableWebMvc
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**");
+    }
+}


### PR DESCRIPTION
## Qual o objetive desta Pull Request?
Esta PR entrega o arquivo de configuração que habilita o CORS na nossa API. Dessa forma, aplicações rodando em outros endereços e portas (locais ou não) podem enviar requests para os endpoints da nossa API. Esta PR habilita requests de qualquer endereço para qualquer endpoint.